### PR TITLE
feat: Mejora de migración, seeder y modelo de Payments

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -7,14 +7,22 @@ use Illuminate\Database\Eloquent\Model;
 class Payment extends Model
 {
     protected $fillable = [
-        'registration_id', 
-        'amount', 
-        'payment_date', 
-        'payment_method'
+        'registration_id',
+        'amount',
+        'payment_method',
+        'status',
+        'payment_date',
+        'transaction_reference',
+        'note',
+    ];
+
+    protected $casts = [
+        'payment_date' => 'date',
+        'amount' => 'decimal:2',
     ];
 
     public function registration()
     {
-        return $this->belongsTo(Registration::class, 'registration_id');
+        return $this->belongsTo(Registration::class);
     }
 }

--- a/database/migrations/2025_08_15_190922_create_payments_table.php
+++ b/database/migrations/2025_08_15_190922_create_payments_table.php
@@ -4,8 +4,6 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-use function Laravel\Prompts\note;
-
 return new class extends Migration
 {
     /**
@@ -15,10 +13,12 @@ return new class extends Migration
     {
         Schema::create('payments', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('registration_id');
-            $table->decimal('amount', 8, 2);
-            $table->string('payment_method');
+            $table->foreignId('registration_id')->constrained('registrations')->onDelete('cascade');
+            $table->decimal('amount', 10, 2);
+            $table->enum('payment_method', ['tarjeta', 'efectivo', 'transferencia']);
+            $table->enum('status', ['pendiente', 'completado', 'fallido', 'reembolsado'])->default('pendiente');
             $table->date('payment_date');
+            $table->string('transaction_reference')->nullable();
             $table->text('note')->nullable();
             $table->timestamps();
         });

--- a/database/seeders/PaymentsTableSeeder.php
+++ b/database/seeders/PaymentsTableSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\Payment;
 use App\Models\Registration;
+use Carbon\Carbon;
 
 class PaymentsTableSeeder extends Seeder
 {
@@ -14,15 +15,22 @@ class PaymentsTableSeeder extends Seeder
      */
     public function run(): void
     {
-        $registrations = Registration::all();
-        $PAYMENT_METHODS = ['card', 'efective', 'transfer'];
+        $registrations = Registration::with('event')->get();
+        $paymentMethods = ['tarjeta', 'efectivo', 'transferencia'];
+        $statuses = ['pendiente', 'completado', 'fallido', 'reembolsado'];
 
         foreach ($registrations as $registration) {
+            $method = $paymentMethods[array_rand($paymentMethods)];
+            $status = fake()->randomElement($statuses);
+
             Payment::create([
                 'registration_id' => $registration->id,
                 'amount' => $registration->event->price,
-                'payment_date' => now(),
-                'payment_method' => $PAYMENT_METHODS[array_rand($PAYMENT_METHODS)],
+                'payment_method' => $method,
+                'status' => $status,
+                'payment_date' => Carbon::parse($registration->created_at)->addMinutes(rand(1, 60)),
+                'transaction_reference' => $status === 'completado' ? strtoupper(fake()->bothify('PAY-####-????')) : null,
+                'note' => fake()->optional(0.3)->sentence(),
             ]);
         }
     }


### PR DESCRIPTION
## Descripción

Mejoras en la migración, seeder y modelo de la tabla `payments` para una estructura más robusta y consistente.

## Cambios realizados

### Migración (`create_payments_table`)
- **Foreign key**: Se agregó constraint `foreignId` en `registration_id` con `onDelete('cascade')`
- **Status**: Nuevo campo `enum` con valores: `pendiente`, `completado`, `fallido`, `reembolsado` (default: `pendiente`)
- **Payment method**: Cambiado de `string` a `enum` con valores: `tarjeta`, `efectivo`, `transferencia`
- **Transaction reference**: Nuevo campo `string` nullable para referencia de transacción
- **Amount**: Precisión aumentada de `decimal(8,2)` a `decimal(10,2)`
- **Eliminado**: Import innecesario de `Laravel\Prompts\note`

### Seeder (`PaymentsTableSeeder`)
- Corregido typo: `efective` → `efectivo`
- Métodos de pago ahora usan los valores del enum en español
- Generación de fecha de pago relativa al registro
- Referencia de transacción generada solo para pagos completados
- Notas opcionales con datos falsos realistas

### Modelo (`Payment`)
- Agregados nuevos campos al `$fillable`: `status`, `transaction_reference`, `note`
- Agregados `$casts` para `payment_date` (date) y `amount` (decimal:2)
- Simplificada la relación `registration()` (Laravel infiere la FK automáticamente)

## Archivos modificados
- `database/migrations/2025_08_15_190922_create_payments_table.php`
- `database/seeders/PaymentsTableSeeder.php`
- `app/Models/Payment.php`